### PR TITLE
Limit gasPrice in buy

### DIFF
--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -35,6 +35,7 @@ contract StatusContribution is Owned, SafeMath, TokenController {
 
     uint constant public failSafe = 300000 ether;
     uint constant public price = 10**18 / 10000;
+    uint constant public maxGasPrice = 50000000000;  // 50gwei gas price
 
     MiniMeToken public SGT;
     MiniMeToken public SNT;
@@ -195,6 +196,8 @@ contract StatusContribution is Owned, SafeMath, TokenController {
     }
 
     function buyNormal(address _th) internal {
+
+        if (tx.gasprice > maxGasPrice) throw;
         uint toFund;
         uint cap = dynamicCeiling.cap(getBlockNumber());
 

--- a/test/contribution.js
+++ b/test/contribution.js
@@ -120,7 +120,7 @@ contract("StatusContribution", (accounts) => {
 
         await statusContribution.setMockedBlockNumber(1000000);
 
-        await snt.sendTransaction({ value: web3.toWei(1), gas: 300000 });
+        await snt.sendTransaction({ value: web3.toWei(1), gas: 300000, gasPrice: "20000000000" });
 
         const balance = await snt.balanceOf(accounts[ 0 ]);
 
@@ -129,7 +129,7 @@ contract("StatusContribution", (accounts) => {
 
     it("Should return the remaining in the last transaction ", async () => {
         const initailBalance = await web3.eth.getBalance(accounts[ 0 ]);
-        await snt.sendTransaction({ value: web3.toWei(5), gas: 300000 });
+        await snt.sendTransaction({ value: web3.toWei(5), gas: 300000, gasPrice: "20000000000" });
         const finalBalance = await web3.eth.getBalance(accounts[ 0 ]);
 
         const spended = web3.fromWei(initailBalance.sub(finalBalance)).toNumber();
@@ -153,7 +153,7 @@ contract("StatusContribution", (accounts) => {
         await statusContribution.setMockedBlockNumber(1000500);
 
         const initailBalance = await web3.eth.getBalance(accounts[ 0 ]);
-        await snt.sendTransaction({ value: web3.toWei(10), gas: 300000 });
+        await snt.sendTransaction({ value: web3.toWei(10), gas: 300000, gasPrice: "20000000000" });
         const finalBalance = await web3.eth.getBalance(accounts[ 0 ]);
 
         const spended = web3.fromWei(initailBalance.sub(finalBalance)).toNumber();
@@ -179,7 +179,7 @@ contract("StatusContribution", (accounts) => {
         const initailBalance = await web3.eth.getBalance(accounts[ 0 ]);
         await statusContribution.proxyPayment(
             accounts[ 1 ],
-            { value: web3.toWei(15), gas: 300000, from: accounts[ 0 ] });
+            { value: web3.toWei(15), gas: 300000, from: accounts[ 0 ], gasPrice: "20000000000" });
 
         const finalBalance = await web3.eth.getBalance(accounts[ 0 ]);
 
@@ -207,8 +207,8 @@ contract("StatusContribution", (accounts) => {
     });
 
     it("Guaranteed address should still be able to buy", async () => {
-        await snt.sendTransaction({ value: web3.toWei(3), gas: 300000, from: accounts[ 7 ] });
-        await snt.sendTransaction({ value: web3.toWei(3), gas: 300000, from: accounts[ 8 ] });
+        await snt.sendTransaction({ value: web3.toWei(3), gas: 300000, from: accounts[ 7 ], gasPrice: "20000000000" });
+        await snt.sendTransaction({ value: web3.toWei(3), gas: 300000, from: accounts[ 8 ], gasPrice: "20000000000" });
 
         const balance7 = await snt.balanceOf(accounts[ 7 ]);
         const balance8 = await snt.balanceOf(accounts[ 8 ]);


### PR DESCRIPTION
This pull requests fixes a limit of 50Gwei for the buy transactions.  This should allow that any user that wants to use the network during the sale, can do it setting the gasPrice over 50Gwei.  Also will equalize opportunities to all the participamts.