### PR TITLE
contracts: DynamicCeiling: Remove unused `CurvePoint.revealed`

### DIFF
--- a/contracts/DynamicCeiling.sol
+++ b/contracts/DynamicCeiling.sol
@@ -34,7 +34,6 @@ contract DynamicCeiling is SafeMath {
         bytes32 hash;
         uint block;
         uint limit;
-        bool revealed;
     }
 
     address public creator;
@@ -77,7 +76,6 @@ contract DynamicCeiling is SafeMath {
         }
         points[revealedPoints].block = _block;
         points[revealedPoints].limit = _limit;
-        points[revealedPoints].revealed = true;
         revealedPoints = safeAdd(revealedPoints, 1);
         if (_last) allRevealed = true;
     }


### PR DESCRIPTION
Doesn't fill any function. Point can be inferred to be revealed
by having an index less than `revealedPoints`.