### PR TITLE
contracts: DynamicCeiling: revealPoint: Remove `_last` to prevent errors

### DIFF
--- a/contracts/DynamicCeiling.sol
+++ b/contracts/DynamicCeiling.sol
@@ -21,8 +21,7 @@ pragma solidity ^0.4.11;
 /// @author Jordi Baylina
 /// @dev This contract calculates the A cailing from a series of points.
 ///  This points are commited firs and revealed later.
-///  All the points must be in increasing order and the last point is marked
-///  as the last one.
+///  All the points must be in increasing order.
 ///  This contract allows to hide and reveal the ceiling at will of the owner.
 
 
@@ -46,7 +45,7 @@ contract DynamicCeiling is SafeMath {
         creator = msg.sender;
     }
 
-    /// @notice This should be called by the creator of the contract to commit
+    /// @notice This needs to be called by the creator of the contract to commit
     ///  all the points of the curve.
     /// @param _pointHashes Array of hashes of each point. Each hash is callculated
     ///  by the `calculateHash` method. More hashes that the actual points of the curve
@@ -66,11 +65,10 @@ contract DynamicCeiling is SafeMath {
     /// @param _block Block number where this point of the curve is defined.
     ///  (Must be greater than the previous one)
     /// @param _limit Ceiling cat at that block.
-    /// @param _last `true` if it's the last point of the curve.
     /// @param _salt Random number used to commit the point
-    function revealPoint(uint _block, uint _limit, bool _last, bytes32 _salt) {
+    function revealPoint(uint _block, uint _limit, bytes32 _salt) {
         if (allRevealed) throw;
-        if (points[revealedPoints].hash != sha3(_block, _limit, _last, _salt)) throw;
+        if (points[revealedPoints].hash != sha3(_block, _limit, _salt)) throw;
         if (revealedPoints > 0) {
             if (_block <= points[safeSub(revealedPoints, 1)].block) throw;
             if (_limit < points[safeSub(revealedPoints, 1)].limit) throw;
@@ -79,7 +77,7 @@ contract DynamicCeiling is SafeMath {
         points[revealedPoints].limit = _limit;
         points[revealedPoints].revealed = true;
         revealedPoints = safeAdd(revealedPoints, 1);
-        if (_last) allRevealed = true;
+        if (revealedPoints >= points.length) allRevealed = true;
     }
 
     /// @return Return the limit at specific block number
@@ -117,12 +115,11 @@ contract DynamicCeiling is SafeMath {
     /// @param _block Block number where this point of the curve is defined.
     ///  (Must be greater than the previous one)
     /// @param _limit Ceiling cat at that block.
-    /// @param _last `true` if it's the last point of the curve.
     /// @param _salt Random number that will be needed to reveal this point.
     /// @return The calculated hash of this point to be used in the
     ///  `setHiddenPoints` method
-    function calculateHash(uint _block, uint _limit, bool _last, bytes32 _salt) constant returns (bytes32) {
-        return sha3(_block, _limit, _last, _salt);
+    function calculateHash(uint _block, uint _limit, bytes32 _salt) constant returns (bytes32) {
+        return sha3(_block, _limit, _salt);
     }
 
     /// @return Return the total number of points commited

--- a/test/dynamicCeiling.js
+++ b/test/dynamicCeiling.js
@@ -48,7 +48,6 @@ contract("DynamicCeiling", () => {
         await dynamicCeiling.revealPoint(
                 points[ 0 ][ 0 ],
                 points[ 0 ][ 1 ],
-                false,
                 web3.sha3("pwd0"));
 
         assert.equal(await dynamicCeiling.revealedPoints(), 1);
@@ -73,7 +72,6 @@ contract("DynamicCeiling", () => {
         await dynamicCeiling.revealPoint(
                 points[ 1 ][ 0 ],
                 points[ 1 ][ 1 ],
-                false,
                 web3.sha3("pwd1"));
 
         assert.equal(await dynamicCeiling.revealedPoints(), 2);
@@ -98,7 +96,6 @@ contract("DynamicCeiling", () => {
         await dynamicCeiling.revealPoint(
                 points[ 2 ][ 0 ],
                 points[ 2 ][ 1 ],
-                true,
                 web3.sha3("pwd2"));
 
         assert.equal(await dynamicCeiling.revealedPoints(), 3);

--- a/test/helpers/hiddenPoints.js
+++ b/test/helpers/hiddenPoints.js
@@ -5,7 +5,6 @@ exports.setHiddenPoints = async (dynamicCeiling, points) => {
         const h = await dynamicCeiling.calculateHash(
             p[ 0 ],
             p[ 1 ],
-            i === points.length - 1,
             web3.sha3(`pwd${ i }`));
         hashes.push(h);
         i += 1;


### PR DESCRIPTION
Prevent potential errors from committing points without marking one as
last, or marking multiple as last.