### PR TITLE
contracts: StatusContribution: Improve exchange rate logic

### DIFF
--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -34,7 +34,7 @@ import "./SafeMath.sol";
 contract StatusContribution is Owned, SafeMath, TokenController {
 
     uint constant public failSafe = 300000 ether;
-    uint constant public price = 10**18 / 10000;
+    uint constant public exchangeRate = 10000;
     uint constant public SGTPreferenceBlocks = 2000;
 
     MiniMeToken public SGT;
@@ -119,6 +119,7 @@ contract StatusContribution is Owned, SafeMath, TokenController {
 
         if (SNT.totalSupply() != 0) throw;
         if (SNT.controller() != address(this)) throw;
+        if (SNT.decimals() != 18) throw;  // Same amount of decimals as ETH
 
         if (_stopBlock < _startBlock) throw;
 
@@ -239,9 +240,7 @@ contract StatusContribution is Owned, SafeMath, TokenController {
         if (_toFund == 0) throw; // Do not spend gas for
         if (msg.value < _toFund) throw;  // Not needed, but double check.
 
-        uint tokensGenerated = safeDiv(
-                                    safeMul(_toFund, 10** uint(SNT.decimals()) ),
-                                    price);
+        uint tokensGenerated = safeMul(_toFund, exchangeRate);
         uint toReturn = safeSub(msg.value, _toFund);
 
         if (!SNT.generateTokens(_th, tokensGenerated))
@@ -454,4 +453,3 @@ contract StatusContribution is Owned, SafeMath, TokenController {
     event GuaranteedAddress(address indexed th, uint limiy);
     event Finalized();
 }
-


### PR DESCRIPTION
Prevents the MiniMeToken from having a different number of decimals than
expected. Causing a mismatch between the tokens generated and the
decimals.
Simplifies the price and exchange rate logic.