### PR TITLE
contracts: StatusContribution: Fix finalize at `stopBlock`

### DIFF
--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -287,17 +287,14 @@ contract StatusContribution is Owned, SafeMath, TokenController {
     ///  controller.
     function finalize() initialized {
         if (getBlockNumber() < startBlock) throw;
-
-        if ((msg.sender != owner)&&(getBlockNumber() < stopBlock )) throw;
-
-        if (finalized>0) throw;
+        if (msg.sender != owner && getBlockNumber() < stopBlock) throw;
+        if (finalized > 0) throw;
 
         // Do not allow terminate until all revealed.
         if (!dynamicCeiling.allRevealed()) throw;
 
-
         // Allow premature finalization if final limit is reached
-        if (getBlockNumber () <= stopBlock) {
+        if (getBlockNumber () < stopBlock) {
             var (,,lastLimit,) = dynamicCeiling.points( safeSub(dynamicCeiling.revealedPoints(), 1));
 
             if (totalCollected()< lastLimit) throw;


### PR DESCRIPTION
If someone other than the owner called `finalize()` at the `stopBlock` then premature finalization would be triggered.