### PR TITLE
contracts: Fix formatting

### DIFF
--- a/contracts/ContributionWallet.sol
+++ b/contracts/ContributionWallet.sol
@@ -24,41 +24,44 @@ pragma solidity ^0.4.11;
 ///  period. So all the ETH collected will be locked here until the contribution
 ///  period ends
 
-
-import "./StatusContribution.sol";
-
 // @dev Contract to hold sale raised funds during the sale period.
 // Prevents attack in which the Aragon Multisig sends raised ether
 // to the sale contract to mint tokens to itself, and getting the
 // funds back immediately.
 
+
+import "./StatusContribution.sol";
+
+
 contract ContributionWallet {
-  // Public variables
-  address public multisig;
-  uint public finalBlock;
-  StatusContribution public contribution;
 
-  // @dev Constructor initializes public variables
-  // @param _multisig The address of the multisig that will receive the funds
-  // @param _finalBlock Block after which the multisig can request the funds
-  // @param _contribution Address of the StatusContribution contract
-  function ContributionWallet(address _multisig, uint _finalBlock, address _contribution) {
-    multisig = _multisig;
-    finalBlock = _finalBlock;
-    contribution = StatusContribution(_contribution);
-  }
+    // Public variables
+    address public multisig;
+    uint public finalBlock;
+    StatusContribution public contribution;
 
-  // @dev Receive all sent funds without any further logic
-  function () public payable {}
+    // @dev Constructor initializes public variables
+    // @param _multisig The address of the multisig that will receive the funds
+    // @param _finalBlock Block after which the multisig can request the funds
+    // @param _contribution Address of the StatusContribution contract
+    function ContributionWallet(address _multisig, uint _finalBlock, address _contribution) {
+        multisig = _multisig;
+        finalBlock = _finalBlock;
+        contribution = StatusContribution(_contribution);
+    }
 
-  // @dev Withdraw function sends all the funds to the wallet if conditions are correct
-  function withdraw() public {
-    if (msg.sender != multisig) throw;                       // Only the multisig can request it
-    if (block.number > finalBlock) return doWithdraw();      // Allow after the final block
-    if (contribution.finalized() != 0) return doWithdraw();      // Allow when sale is finalized
-  }
+    // @dev Receive all sent funds without any further logic
+    function () public payable {}
 
-  function doWithdraw() internal {
-    if (!multisig.send(this.balance)) throw;
-  }
+    // @dev Withdraw function sends all the funds to the wallet if conditions are correct
+    function withdraw() public {
+        if (msg.sender != multisig) throw;                       // Only the multisig can request it
+        if (block.number > finalBlock) return doWithdraw();      // Allow after the final block
+        if (contribution.finalized() != 0) return doWithdraw();  // Allow when sale is finalized
+    }
+
+    function doWithdraw() internal {
+        if (!multisig.send(this.balance)) throw;
+    }
+
 }

--- a/contracts/DevTokensHolder.sol
+++ b/contracts/DevTokensHolder.sol
@@ -41,9 +41,11 @@ pragma solidity ^0.4.11;
 //     Contrib   6 Months       24 Months
 //       End
 
+
 import "./MiniMeToken.sol";
 import "./StatusContribution.sol";
 import "./SafeMath.sol";
+
 
 contract DevTokensHolder is Owned, SafeMath {
 
@@ -68,11 +70,7 @@ contract DevTokensHolder is Owned, SafeMath {
         if (finalized == 0) throw;
         if (safeSub(getTime(), finalized) <= months(6)) throw;
 
-        uint canExtract = safeMul(
-                                total,
-                                safeDiv(
-                                    safeSub( getTime(), finalized),
-                                    months(24)));
+        uint canExtract = safeMul(total, safeDiv(safeSub(getTime(), finalized), months(24)));
 
         canExtract = safeSub(canExtract, collectedTokens);
 
@@ -95,25 +93,25 @@ contract DevTokensHolder is Owned, SafeMath {
     }
 
 
-//////////
-// Safety Methods
-//////////
+    //////////
+    // Safety Methods
+    //////////
 
     /// @notice This method can be used by the controller to extract mistakenly
     ///  sent tokens to this contract.
     /// @param _token The address of the token contract that you want to recover
     ///  set to 0 in case you want to extract ether.
     function claimTokens(address _token) onlyOwner {
-      if (_token == address(snt)) throw;
-      if (_token == 0x0) {
-          owner.transfer(this.balance);
-          return;
-      }
+        if (_token == address(snt)) throw;
+        if (_token == 0x0) {
+            owner.transfer(this.balance);
+            return;
+        }
 
-      MiniMeToken token = MiniMeToken(_token);
-      uint balance = token.balanceOf(this);
-      token.transfer(owner, balance);
-      ClaimedTokens(_token, owner, balance);
+        MiniMeToken token = MiniMeToken(_token);
+        uint balance = token.balanceOf(this);
+        token.transfer(owner, balance);
+        ClaimedTokens(_token, owner, balance);
     }
 
     event ClaimedTokens(address indexed token, address indexed controller, uint amount);

--- a/contracts/DynamicCeiling.sol
+++ b/contracts/DynamicCeiling.sol
@@ -28,6 +28,7 @@ pragma solidity ^0.4.11;
 
 import "./SafeMath.sol";
 
+
 contract DynamicCeiling is SafeMath {
 
     struct CurvePoint {
@@ -55,8 +56,9 @@ contract DynamicCeiling is SafeMath {
     function setHiddenPoints(bytes32[] _pointHashes) {
         if (msg.sender != creator) throw;
         if (points.length > 0) throw;
+
         points.length = _pointHashes.length;
-        for (uint i=0; i< _pointHashes.length; i = safeAdd(i,1)) {
+        for (uint i = 0; i < _pointHashes.length; i = safeAdd(i, 1)) {
             points[i].hash = _pointHashes[i];
         }
     }
@@ -89,13 +91,13 @@ contract DynamicCeiling is SafeMath {
         if (revealedPoints == 0) return 0;
 
         // Shortcut if _block is after most recently revealed point
-        if (_block >= points[safeSub(revealedPoints,1)].block)
-            return points[safeSub(revealedPoints,1)].limit;
+        if (_block >= points[safeSub(revealedPoints, 1)].block)
+            return points[safeSub(revealedPoints, 1)].limit;
         if (_block < points[0].block) return 0;
 
         // Binary search of the value in the array
         uint min = 0;
-        uint max = safeSub(revealedPoints,1);
+        uint max = safeSub(revealedPoints, 1);
         while (max != safeAdd(min, 1)) {
             uint mid = safeDiv(safeAdd(max, min), 2);
             if (points[mid].block<=_block) {
@@ -105,13 +107,10 @@ contract DynamicCeiling is SafeMath {
             }
         }
 
-        return safeAdd(
-                    points[min].limit,
-                    safeDiv(
-                        safeMul(
-                            safeSub(_block, points[min].block),
-                            safeSub(points[max].limit, points[min].limit)),
-                        safeSub(points[max].block, points[min].block)));
+        return safeAdd(points[min].limit,
+                       safeDiv(safeMul(safeSub(_block, points[min].block),
+                                       safeSub(points[max].limit, points[min].limit)),
+                               safeSub(points[max].block, points[min].block)));
 
     }
 
@@ -133,4 +132,5 @@ contract DynamicCeiling is SafeMath {
     function nPoints() constant returns(uint) {
         return points.length;
     }
+
 }

--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -1,16 +1,23 @@
 pragma solidity ^0.4.11;
 
+
 /// @dev `Owned` is a base level contract that assigns an `owner` that can be
 ///  later changed
 contract Owned {
+
     /// @dev `owner` is the only address that can call a function with this
     /// modifier
-    modifier onlyOwner { if (msg.sender != owner) throw; _; }
+    modifier onlyOwner {
+        if (msg.sender != owner) throw;
+        _;
+    }
 
     address public owner;
 
     /// @notice The Constructor assigns the message sender to be `owner`
-    function Owned() { owner = msg.sender;}
+    function Owned() {
+        owner = msg.sender;
+    }
 
     /// @notice `owner` can step down and assign some other address to this role
     /// @param _newOwner The address of the new owner. 0x0 can be used to create
@@ -18,4 +25,5 @@ contract Owned {
     function changeOwner(address _newOwner) onlyOwner {
         owner = _newOwner;
     }
+
 }

--- a/contracts/SGT.sol
+++ b/contracts/SGT.sol
@@ -1,35 +1,38 @@
 pragma solidity ^0.4.11;
 
-import "./MiniMeToken.sol";
-
 /*
     Copyright 2017, Jarrad Hope (Status Research & Development GmbH)
 */
 
-contract SGT is MiniMeToken {
-  uint constant D160 = 0x0010000000000000000000000000000000000000000;
 
-  function SGT(
-    address _tokenFactory
-  ) MiniMeToken(
-    _tokenFactory,
-    0x0,                    // no parent token
-    0,                      // no snapshot block number from parent
-    "Status Genesis Token", // Token name
-    1,                     // Decimals
-    "SGT",                  // Symbol
-    false                    // Enable transfers
-    ) {}
+import "./MiniMeToken.sol";
+
+
+contract SGT is MiniMeToken {
+
+    uint constant D160 = 0x0010000000000000000000000000000000000000000;
+
+    function SGT(address _tokenFactory)
+            MiniMeToken(
+                _tokenFactory,
+                0x0,                     // no parent token
+                0,                       // no snapshot block number from parent
+                "Status Genesis Token",  // Token name
+                1,                       // Decimals
+                "SGT",                   // Symbol
+                false                    // Enable transfers
+            ) {}
 
     // data is an array of uints. Each uint represents a transfer.
     // The 160 LSB is the destination of the address that wants to be sent
     // The 96 MSB is the amount of tokens that wants to be sent.
     function multiMint(uint[] data) onlyController {
-        for (uint i = 0; i < data.length; i++ ) {
-            address addr = address( data[i] & (D160-1) );
+        for (uint i = 0; i < data.length; i++) {
+            address addr = address(data[i] & (D160 - 1));
             uint amount = data[i] / D160;
 
             if (!generateTokens(addr, amount)) throw;
         }
     }
+
 }

--- a/contracts/SGTExchanger.sol
+++ b/contracts/SGTExchanger.sol
@@ -51,9 +51,7 @@ contract SGTExchanger is TokenController, SafeMath, Owned {
         uint balance = sgt.balanceOf(msg.sender);
 
         // First calculate how much correspond to him
-        uint amount = safeDiv(
-                        safeMul(total , balance),
-                        sgt.totalSupply());
+        uint amount = safeDiv(safeMul(total, balance), sgt.totalSupply());
 
         // And then subtract the amount already collected
         amount = safeSub(amount, collected[msg.sender]);
@@ -70,35 +68,37 @@ contract SGTExchanger is TokenController, SafeMath, Owned {
         throw;
     }
 
-    function onTransfer(address , address , uint ) returns(bool) {
+    function onTransfer(address, address, uint) returns(bool) {
         return false;
     }
 
-    function onApprove(address , address , uint ) returns(bool) {
+    function onApprove(address, address, uint) returns(bool) {
         return false;
     }
 
-//////////
-// Safety Method
-//////////
+
+    //////////
+    // Safety Method
+    //////////
 
     /// @notice This method can be used by the controller to extract mistakenly
     ///  sent tokens to this contract.
     /// @param _token The address of the token contract that you want to recover
     ///  set to 0 in case you want to extract ether.
     function claimTokens(address _token) onlyOwner {
-      if (_token == address(snt)) throw;
-      if (_token == 0x0) {
-          owner.transfer(this.balance);
-          return;
-      }
+        if (_token == address(snt)) throw;
+        if (_token == 0x0) {
+            owner.transfer(this.balance);
+            return;
+        }
 
-      MiniMeToken token = MiniMeToken(_token);
-      uint balance = token.balanceOf(this);
-      token.transfer(owner, balance);
-      ClaimedTokens(_token, owner, balance);
+        MiniMeToken token = MiniMeToken(_token);
+        uint balance = token.balanceOf(this);
+        token.transfer(owner, balance);
+        ClaimedTokens(_token, owner, balance);
     }
 
     event ClaimedTokens(address indexed token, address indexed controller, uint amount);
     event TokensCollected(address indexed holder, uint amount);
+
 }

--- a/contracts/SNT.sol
+++ b/contracts/SNT.sol
@@ -1,22 +1,23 @@
 pragma solidity ^0.4.11;
 
-import "./MiniMeToken.sol";
-
 /*
     Copyright 2017, Jarrad Hope (Status Research & Development GmbH)
 */
 
+
+import "./MiniMeToken.sol";
+
+
 contract SNT is MiniMeToken {
-  // @dev SNT constructor just parametrizes the MiniMeIrrevocableVestedToken constructor
-  function SNT(
-    address _tokenFactory
-  ) MiniMeToken(
-    _tokenFactory,
-    0x0,                    // no parent token
-    0,                      // no snapshot block number from parent
-    "Status Network Token", // Token name
-    18,                     // Decimals
-    "SNT",                  // Symbol
-    true                    // Enable transfers
-    ) {}
+    // @dev SNT constructor just parametrizes the MiniMeIrrevocableVestedToken constructor
+    function SNT(address _tokenFactory)
+            MiniMeToken(
+                _tokenFactory,
+                0x0,                     // no parent token
+                0,                       // no snapshot block number from parent
+                "Status Network Token",  // Token name
+                18,                      // Decimals
+                "SNT",                   // Symbol
+                true                     // Enable transfers
+            ) {}
 }

--- a/contracts/SNTPlaceHolder.sol
+++ b/contracts/SNTPlaceHolder.sol
@@ -1,10 +1,5 @@
 pragma solidity ^0.4.11;
 
-import "./MiniMeToken.sol";
-import "./StatusContribution.sol";
-import "./SafeMath.sol";
-import "./Owned.sol";
-
 /*
     Copyright 2017, Jordi Baylina
 
@@ -30,97 +25,106 @@ import "./Owned.sol";
 ///  logic for transferring control of the token to the network when the offering
 ///  asks it to do so.
 
+
+import "./MiniMeToken.sol";
+import "./StatusContribution.sol";
+import "./SafeMath.sol";
+import "./Owned.sol";
+
+
 contract SNTPlaceHolder is TokenController, SafeMath, Owned {
-  MiniMeToken public snt;
-  StatusContribution public contribution;
-  uint public activationTime;
-  address public sgtExchanger;
+    MiniMeToken public snt;
+    StatusContribution public contribution;
+    uint public activationTime;
+    address public sgtExchanger;
 
-  /// @notice Constructor
-  /// @param _owner Trusted owner for this contract.
-  /// @param _snt SNT token contract address
-  /// @param _contribution StatusContribution contract address
-  /// @param _sgtExchanger SGT-SNT Exchange address. (During the first week
-  ///  only this exchanger will be able to move tokens)
-  function SNTPlaceHolder(address _owner, address _snt, address _contribution, address _sgtExchanger) {
-    owner = _owner;
-    snt = MiniMeToken(_snt);
-    contribution = StatusContribution(_contribution);
-    sgtExchanger = _sgtExchanger;
-  }
-
-  /// @notice The owner of this contract can change the controller of the SNT token
-  ///  Please, be sure that the owner is a trusted agent or 0x0 address.
-  /// @param _newController The address of the new controller
-
-  function changeController(address _newController) onlyOwner {
-    snt.changeController(_newController);
-    ControllerChanged(_newController);
-  }
-
-
-//////////
-// MiniMe Controller Interface functions
-//////////
-
-  // In between the offering and the network. Default settings for allowing token transfers.
-  function proxyPayment(address ) payable returns (bool) {
-    return false;
-  }
-
-  function onTransfer(address _from, address , uint ) returns (bool) {
-    return transferable(_from);
-  }
-
-  function onApprove(address _from, address , uint ) returns (bool) {
-    return transferable(_from);
-  }
-
-  function transferable(address _from) internal returns (bool) {
-    // Allow the exchanger to work from the beginning
-    if (activationTime == 0) {
-      uint f = contribution.finalized();
-      if (f>0) {
-        activationTime = safeAdd(f, 1 weeks);
-      } else {
-        return false;
-      }
+    /// @notice Constructor
+    /// @param _owner Trusted owner for this contract.
+    /// @param _snt SNT token contract address
+    /// @param _contribution StatusContribution contract address
+    /// @param _sgtExchanger SGT-SNT Exchange address. (During the first week
+    ///  only this exchanger will be able to move tokens)
+    function SNTPlaceHolder(address _owner, address _snt, address _contribution, address _sgtExchanger) {
+        owner = _owner;
+        snt = MiniMeToken(_snt);
+        contribution = StatusContribution(_contribution);
+        sgtExchanger = _sgtExchanger;
     }
-    return (getTime() > activationTime) || (_from == sgtExchanger);
-  }
 
-//////////
-// Testing specific methods
-//////////
+    /// @notice The owner of this contract can change the controller of the SNT token
+    ///  Please, be sure that the owner is a trusted agent or 0x0 address.
+    /// @param _newController The address of the new controller
 
-  /// @notice This function is overrided by the test Mocks.
-  function getTime() internal returns(uint) {
-    return now;
-  }
+    function changeController(address _newController) onlyOwner {
+        snt.changeController(_newController);
+        ControllerChanged(_newController);
+    }
 
-//////////
-// Safety Methods
-//////////
 
-  /// @notice This method can be used by the controller to extract mistakenly
-  ///  sent tokens to this contract.
-  /// @param _token The address of the token contract that you want to recover
-  ///  set to 0 in case you want to extract ether.
-  function claimTokens(address _token) onlyOwner {
-      if (snt.controller() == address(this)) {
-          snt.claimTokens(_token);
-      }
-      if (_token == 0x0) {
-          owner.transfer(this.balance);
-          return;
-      }
+    //////////
+    // MiniMe Controller Interface functions
+    //////////
 
-      MiniMeToken token = MiniMeToken(_token);
-      uint balance = token.balanceOf(this);
-      token.transfer(owner, balance);
-      ClaimedTokens(_token, owner, balance);
-  }
+    // In between the offering and the network. Default settings for allowing token transfers.
+    function proxyPayment(address) payable returns (bool) {
+        return false;
+    }
 
-  event ClaimedTokens(address indexed token, address indexed controller, uint amount);
-  event ControllerChanged(address indexed newController);
+    function onTransfer(address _from, address, uint) returns (bool) {
+        return transferable(_from);
+    }
+
+    function onApprove(address _from, address, uint) returns (bool) {
+        return transferable(_from);
+    }
+
+    function transferable(address _from) internal returns (bool) {
+        // Allow the exchanger to work from the beginning
+        if (activationTime == 0) {
+            uint f = contribution.finalized();
+            if (f > 0) {
+                activationTime = safeAdd(f, 1 weeks);
+            } else {
+                return false;
+            }
+        }
+        return (getTime() > activationTime) || (_from == sgtExchanger);
+    }
+
+
+    //////////
+    // Testing specific methods
+    //////////
+
+    /// @notice This function is overrided by the test Mocks.
+    function getTime() internal returns(uint) {
+        return now;
+    }
+
+
+    //////////
+    // Safety Methods
+    //////////
+
+    /// @notice This method can be used by the controller to extract mistakenly
+    ///  sent tokens to this contract.
+    /// @param _token The address of the token contract that you want to recover
+    ///  set to 0 in case you want to extract ether.
+    function claimTokens(address _token) onlyOwner {
+        if (snt.controller() == address(this)) {
+            snt.claimTokens(_token);
+        }
+        if (_token == 0x0) {
+            owner.transfer(this.balance);
+            return;
+        }
+
+        MiniMeToken token = MiniMeToken(_token);
+        uint balance = token.balanceOf(this);
+        token.transfer(owner, balance);
+        ClaimedTokens(_token, owner, balance);
+    }
+
+    event ClaimedTokens(address indexed token, address indexed controller, uint amount);
+    event ControllerChanged(address indexed newController);
 }

--- a/test/helpers/DevTokensHolderMock.sol
+++ b/test/helpers/DevTokensHolderMock.sol
@@ -6,18 +6,18 @@ import '../../contracts/DevTokensHolder.sol';
 
 contract DevTokensHolderMock is DevTokensHolder {
 
-  uint mock_time;
+    uint mock_time;
 
-  function DevTokensHolderMock(address _owner, address _contribution, address _snt)
+    function DevTokensHolderMock(address _owner, address _contribution, address _snt)
     DevTokensHolder(_owner, _contribution, _snt) {
         mock_time = now;
-  }
+    }
 
-  function getTime() internal returns (uint) {
-    return mock_time;
-  }
+    function getTime() internal returns (uint) {
+        return mock_time;
+    }
 
-  function setMockedTime(uint _t) {
-    mock_time = _t;
-  }
+    function setMockedTime(uint _t) {
+        mock_time = _t;
+    }
 }

--- a/test/helpers/ExternalToken.sol
+++ b/test/helpers/ExternalToken.sol
@@ -4,15 +4,14 @@ import "../../contracts/MiniMeToken.sol";
 
 contract ExternalToken is MiniMeToken {
 
-  function ExternalToken(
-    address _tokenFactory
-  ) MiniMeToken(
-    _tokenFactory,
-    0x0,                    // no parent token
-    0,                      // no snapshot block number from parent
-    "External Token for testing", // Token name
-    1,                     // Decimals
-    "EXT",                  // Symbol
-    true                    // Enable transfers
-    ) {}
+  function ExternalToken(address _tokenFactory)
+          MiniMeToken(
+              _tokenFactory,
+              0x0,                           // no parent token
+              0,                             // no snapshot block number from parent
+              "External Token for testing",  // Token name
+              1,                             // Decimals
+              "EXT",                         // Symbol
+              true                           // Enable transfers
+          ) {}
 }

--- a/test/helpers/ExternalToken.sol
+++ b/test/helpers/ExternalToken.sol
@@ -4,14 +4,14 @@ import "../../contracts/MiniMeToken.sol";
 
 contract ExternalToken is MiniMeToken {
 
-  function ExternalToken(address _tokenFactory)
-          MiniMeToken(
-              _tokenFactory,
-              0x0,                           // no parent token
-              0,                             // no snapshot block number from parent
-              "External Token for testing",  // Token name
-              1,                             // Decimals
-              "EXT",                         // Symbol
-              true                           // Enable transfers
-          ) {}
+    function ExternalToken(address _tokenFactory)
+            MiniMeToken(
+                _tokenFactory,
+                0x0,                           // no parent token
+                0,                             // no snapshot block number from parent
+                "External Token for testing",  // Token name
+                1,                             // Decimals
+                "EXT",                         // Symbol
+                true                           // Enable transfers
+            ) {}
 }

--- a/test/helpers/SNTPlaceHolderMock.sol
+++ b/test/helpers/SNTPlaceHolderMock.sol
@@ -6,18 +6,18 @@ import '../../contracts/SNTPlaceHolder.sol';
 
 contract SNTPlaceHolderMock is SNTPlaceHolder {
 
-  uint mock_time;
+    uint mock_time;
 
-  function SNTPlaceHolderMock (address _owner, address _snt, address _contribution, address _sgtExchanger)
-    SNTPlaceHolder(_owner, _snt, _contribution, _sgtExchanger) {
+    function SNTPlaceHolderMock(address _owner, address _snt, address _contribution, address _sgtExchanger)
+            SNTPlaceHolder(_owner, _snt, _contribution, _sgtExchanger) {
         mock_time = now;
-  }
+    }
 
-  function getTime() internal returns (uint) {
-    return mock_time;
-  }
+    function getTime() internal returns (uint) {
+        return mock_time;
+    }
 
-  function setMockedTime(uint _t) {
-    mock_time = _t;
-  }
+    function setMockedTime(uint _t) {
+        mock_time = _t;
+    }
 }

--- a/test/helpers/StatusContributionMock.sol
+++ b/test/helpers/StatusContributionMock.sol
@@ -6,16 +6,15 @@ import '../../contracts/StatusContribution.sol';
 
 contract StatusContributionMock is StatusContribution {
 
-  function StatusContributionMock () StatusContribution() {
-  }
+    function StatusContributionMock() StatusContribution() {}
 
-  function getBlockNumber() internal constant returns (uint) {
-    return mock_blockNumber;
-  }
+    function getBlockNumber() internal constant returns (uint) {
+        return mock_blockNumber;
+    }
 
-  function setMockedBlockNumber(uint _b) {
-    mock_blockNumber = _b;
-  }
+    function setMockedBlockNumber(uint _b) {
+        mock_blockNumber = _b;
+    }
 
-  uint mock_blockNumber = 1;
+    uint mock_blockNumber = 1;
 }


### PR DESCRIPTION
Partial fix for #36

Excluded all externally imported contracts.

Use `git diff --ignore-all-space` for easy diffing.