### PR TITLE
contracts: Use `.transfer()` instead of `.send()`

### DIFF
--- a/contracts/ContributionWallet.sol
+++ b/contracts/ContributionWallet.sol
@@ -61,7 +61,7 @@ contract ContributionWallet {
     }
 
     function doWithdraw() private {
-        if (!multisig.send(this.balance)) throw;
+        multisig.transfer(this.balance);
     }
 
 }

--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -259,7 +259,7 @@ contract StatusContribution is Owned, SafeMath, TokenController {
 
         if (!SNT.generateTokens(_th, tokensGenerated)) throw;
 
-        if (!destEthDevs.send(_toFund)) throw;
+        destEthDevs.transfer(_toFund);
 
         if (toReturn > 0) {
             // If the call comes from the Token controller,


### PR DESCRIPTION
Fixes #42