### PR TITLE
contracts: Underscore all `event` parameters

### DIFF
--- a/contracts/DevTokensHolder.sol
+++ b/contracts/DevTokensHolder.sol
@@ -114,7 +114,7 @@ contract DevTokensHolder is Owned, SafeMath {
         ClaimedTokens(_token, owner, balance);
     }
 
-    event ClaimedTokens(address indexed token, address indexed controller, uint amount);
-    event TokensWithdrawn(address indexed holder, uint amount);
+    event ClaimedTokens(address indexed _token, address indexed _controller, uint _amount);
+    event TokensWithdrawn(address indexed _holder, uint _amount);
 
 }

--- a/contracts/MiniMeToken.sol
+++ b/contracts/MiniMeToken.sol
@@ -554,13 +554,13 @@ contract MiniMeToken is Controlled {
 // Events
 ////////////////
 
-    event ClaimedTokens(address indexed token, address indexed controller, uint amount);
-    event Transfer(address indexed from, address indexed to, uint256 amount);
-    event NewCloneToken(address indexed cloneToken, uint snapshotBlock);
+    event ClaimedTokens(address indexed _token, address indexed _controller, uint _amount);
+    event Transfer(address indexed _from, address indexed _to, uint256 _amount);
+    event NewCloneToken(address indexed _cloneToken, uint _snapshotBlock);
     event Approval(
-        address indexed owner,
-        address indexed spender,
-        uint256 amount
+        address indexed _owner,
+        address indexed _spender,
+        uint256 _amount
         );
 
 }

--- a/contracts/MultisigWallet.sol
+++ b/contracts/MultisigWallet.sol
@@ -7,15 +7,15 @@ contract MultisigWallet {
 
     uint constant public MAX_OWNER_COUNT = 50;
 
-    event Confirmation(address indexed sender, uint indexed transactionId);
-    event Revocation(address indexed sender, uint indexed transactionId);
-    event Submission(uint indexed transactionId);
-    event Execution(uint indexed transactionId);
-    event ExecutionFailure(uint indexed transactionId);
-    event Deposit(address indexed sender, uint value);
-    event OwnerAddition(address indexed owner);
-    event OwnerRemoval(address indexed owner);
-    event RequirementChange(uint required);
+    event Confirmation(address indexed _sender, uint indexed _transactionId);
+    event Revocation(address indexed _sender, uint indexed _transactionId);
+    event Submission(uint indexed _transactionId);
+    event Execution(uint indexed _transactionId);
+    event ExecutionFailure(uint indexed _transactionId);
+    event Deposit(address indexed _sender, uint _value);
+    event OwnerAddition(address indexed _owner);
+    event OwnerRemoval(address indexed _owner);
+    event RequirementChange(uint _required);
 
     mapping (uint => Transaction) public transactions;
     mapping (uint => mapping (address => bool)) public confirmations;

--- a/contracts/SGTExchanger.sol
+++ b/contracts/SGTExchanger.sol
@@ -98,7 +98,7 @@ contract SGTExchanger is TokenController, SafeMath, Owned {
         ClaimedTokens(_token, owner, balance);
     }
 
-    event ClaimedTokens(address indexed token, address indexed controller, uint amount);
-    event TokensCollected(address indexed holder, uint amount);
+    event ClaimedTokens(address indexed _token, address indexed _controller, uint _amount);
+    event TokensCollected(address indexed _holder, uint _amount);
 
 }

--- a/contracts/SNTPlaceHolder.sol
+++ b/contracts/SNTPlaceHolder.sol
@@ -125,6 +125,6 @@ contract SNTPlaceHolder is TokenController, SafeMath, Owned {
         ClaimedTokens(_token, owner, balance);
     }
 
-    event ClaimedTokens(address indexed token, address indexed controller, uint amount);
-    event ControllerChanged(address indexed newController);
+    event ClaimedTokens(address indexed _token, address indexed _controller, uint _amount);
+    event ControllerChanged(address indexed _newController);
 }

--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -453,8 +453,8 @@ contract StatusContribution is Owned, SafeMath, TokenController {
         ClaimedTokens(_token, owner, balance);
     }
 
-    event ClaimedTokens(address indexed token, address indexed controller, uint amount);
-    event NewSale(address indexed th, uint amount, uint tokens, bool guaranteed);
-    event GuaranteedAddress(address indexed th, uint limit);
+    event ClaimedTokens(address indexed _token, address indexed _controller, uint _amount);
+    event NewSale(address indexed th, uint _amount, uint _tokens, bool _guaranteed);
+    event GuaranteedAddress(address indexed _th, uint _limit);
     event Finalized();
 }


### PR DESCRIPTION
Fixes #35