### PR TITLE
contracts: Fix spacing after `returns`

### DIFF
--- a/contracts/DevTokensHolder.sol
+++ b/contracts/DevTokensHolder.sol
@@ -85,11 +85,11 @@ contract DevTokensHolder is Owned {
         TokensWithdrawn(owner, canExtract);
     }
 
-    function months(uint256 m) internal returns(uint256) {
+    function months(uint256 m) internal returns (uint256) {
         return m.mul(30 days);
     }
 
-    function getTime() internal returns(uint256) {
+    function getTime() internal returns (uint256) {
         return now;
     }
 

--- a/contracts/DynamicCeiling.sol
+++ b/contracts/DynamicCeiling.sol
@@ -128,7 +128,7 @@ contract DynamicCeiling {
     /// @return Return the total number of points committed
     ///  (can be larger than the number of actual points on the curve to hide
     ///  the real number of points)
-    function nPoints() public constant returns(uint256) {
+    function nPoints() public constant returns (uint256) {
         return points.length;
     }
 

--- a/contracts/SGTExchanger.sol
+++ b/contracts/SGTExchanger.sol
@@ -65,15 +65,15 @@ contract SGTExchanger is TokenController, Owned {
         TokensCollected(msg.sender, amount);
     }
 
-    function proxyPayment(address) public payable returns(bool) {
+    function proxyPayment(address) public payable returns (bool) {
         throw;
     }
 
-    function onTransfer(address, address, uint256) public returns(bool) {
+    function onTransfer(address, address, uint256) public returns (bool) {
         return false;
     }
 
-    function onApprove(address, address, uint256) public returns(bool) {
+    function onApprove(address, address, uint256) public returns (bool) {
         return false;
     }
 

--- a/contracts/SNTPlaceHolder.sol
+++ b/contracts/SNTPlaceHolder.sol
@@ -99,7 +99,7 @@ contract SNTPlaceHolder is TokenController, Owned {
     //////////
 
     /// @notice This function is overrided by the test Mocks.
-    function getTime() internal returns(uint256) {
+    function getTime() internal returns (uint256) {
         return now;
     }
 

--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -199,11 +199,11 @@ contract StatusContribution is Owned, TokenController {
         return true;
     }
 
-    function onTransfer(address, address, uint256) public returns(bool) {
+    function onTransfer(address, address, uint256) public returns (bool) {
         return false;
     }
 
-    function onApprove(address, address, uint256) public returns(bool) {
+    function onApprove(address, address, uint256) public returns (bool) {
         return false;
     }
 
@@ -396,7 +396,7 @@ contract StatusContribution is Owned, TokenController {
 
     }
 
-    function percent(uint256 p) internal returns(uint256) {
+    function percent(uint256 p) internal returns (uint256) {
         return p.mul(10**16);
     }
 


### PR DESCRIPTION
Related to #36.