### PR TITLE
Freeze SGT block distribution when finalized sale

### DIFF
--- a/contracts/ContributionWallet.sol
+++ b/contracts/ContributionWallet.sol
@@ -57,7 +57,7 @@ contract ContributionWallet {
     function withdraw() public {
         if (msg.sender != multisig) throw;         // Only the multisig can request it
         if (block.number <= endBlock &&            // Allow after end block
-            contribution.finalized() == 0) throw;  // Allow when sale is finalized
+            contribution.finalizedBlock() == 0) throw;  // Allow when sale is finalized
         multisig.transfer(this.balance);
     }
 

--- a/contracts/DevTokensHolder.sol
+++ b/contracts/DevTokensHolder.sol
@@ -66,12 +66,12 @@ contract DevTokensHolder is Owned {
         uint256 balance = snt.balanceOf(address(this));
         uint256 total = collectedTokens.add(snt.balanceOf(address(this)));
 
-        uint256 finalized = contribution.finalized();
+        uint256 finalizedTime = contribution.finalizedTime();
 
-        if (finalized == 0) throw;
-        if (getTime().sub(finalized) <= months(6)) throw;
+        if (finalizedTime == 0) throw;
+        if (getTime().sub(finalizedTime) <= months(6)) throw;
 
-        uint256 canExtract = total.mul(getTime().sub(finalized).div(months(24)));
+        uint256 canExtract = total.mul(getTime().sub(finalizedTime).div(months(24)));
 
         canExtract = canExtract.sub(collectedTokens);
 

--- a/contracts/MiniMeToken.sol
+++ b/contracts/MiniMeToken.sol
@@ -155,7 +155,7 @@ contract MiniMeToken is Controlled {
         parentToken = MiniMeToken(_parentToken);
         parentSnapShotBlock = _parentSnapShotBlock;
         transfersEnabled = _transfersEnabled;
-        creationBlock = block.number;
+        creationBlock = getBlockNumber();
     }
 
 
@@ -208,14 +208,14 @@ contract MiniMeToken is Controlled {
                return true;
            }
 
-           if (parentSnapShotBlock >= block.number) throw;
+           if (parentSnapShotBlock >= getBlockNumber()) throw;
 
            // Do not allow transfer to 0x0 or the token contract itself
            if ((_to == 0) || (_to == address(this))) throw;
 
            // If the amount being transfered is more than the balance of the
            //  account the transfer returns false
-           var previousBalanceFrom = balanceOfAt(_from, block.number);
+           var previousBalanceFrom = balanceOfAt(_from, getBlockNumber());
            if (previousBalanceFrom < _amount) {
                return false;
            }
@@ -232,7 +232,7 @@ contract MiniMeToken is Controlled {
 
            // Then update the balance array with the new value for the address
            //  receiving the tokens
-           var previousBalanceTo = balanceOfAt(_to, block.number);
+           var previousBalanceTo = balanceOfAt(_to, getBlockNumber());
            if (previousBalanceTo + _amount < previousBalanceTo) throw; // Check for overflow
            updateValueAtNow(balances[_to], previousBalanceTo + _amount);
 
@@ -245,7 +245,7 @@ contract MiniMeToken is Controlled {
     /// @param _owner The address that's balance is being requested
     /// @return The balance of `_owner` at the current block
     function balanceOf(address _owner) constant returns (uint256 balance) {
-        return balanceOfAt(_owner, block.number);
+        return balanceOfAt(_owner, getBlockNumber());
     }
 
     /// @notice `msg.sender` approves `_spender` to spend `_amount` tokens on
@@ -308,7 +308,7 @@ contract MiniMeToken is Controlled {
     /// @dev This function makes it easy to get the total number of tokens
     /// @return The total number of tokens
     function totalSupply() constant returns (uint) {
-        return totalSupplyAt(block.number);
+        return totalSupplyAt(getBlockNumber());
     }
 
 
@@ -388,7 +388,7 @@ contract MiniMeToken is Controlled {
         uint _snapshotBlock,
         bool _transfersEnabled
         ) returns(address) {
-        if (_snapshotBlock == 0) _snapshotBlock = block.number;
+        if (_snapshotBlock == 0) _snapshotBlock = getBlockNumber();
         MiniMeToken cloneToken = tokenFactory.createCloneToken(
             this,
             _snapshotBlock,
@@ -415,7 +415,7 @@ contract MiniMeToken is Controlled {
     /// @return True if the tokens are generated correctly
     function generateTokens(address _owner, uint _amount
     ) onlyController returns (bool) {
-        uint curTotalSupply = getValueAt(totalSupplyHistory, block.number);
+        uint curTotalSupply = getValueAt(totalSupplyHistory, getBlockNumber());
         if (curTotalSupply + _amount < curTotalSupply) throw; // Check for overflow
         updateValueAtNow(totalSupplyHistory, curTotalSupply + _amount);
         var previousBalanceTo = balanceOf(_owner);
@@ -432,7 +432,7 @@ contract MiniMeToken is Controlled {
     /// @return True if the tokens are burned correctly
     function destroyTokens(address _owner, uint _amount
     ) onlyController returns (bool) {
-        uint curTotalSupply = getValueAt(totalSupplyHistory, block.number);
+        uint curTotalSupply = getValueAt(totalSupplyHistory, getBlockNumber());
         if (curTotalSupply < _amount) throw;
         updateValueAtNow(totalSupplyHistory, curTotalSupply - _amount);
         var previousBalanceFrom = balanceOf(_owner);
@@ -491,9 +491,9 @@ contract MiniMeToken is Controlled {
     function updateValueAtNow(Checkpoint[] storage checkpoints, uint _value
     ) internal  {
         if ((checkpoints.length == 0)
-        || (checkpoints[checkpoints.length -1].fromBlock < block.number)) {
+        || (checkpoints[checkpoints.length -1].fromBlock < getBlockNumber())) {
                Checkpoint newCheckPoint = checkpoints[ checkpoints.length++ ];
-               newCheckPoint.fromBlock =  uint128(block.number);
+               newCheckPoint.fromBlock =  uint128(getBlockNumber());
                newCheckPoint.value = uint128(_value);
            } else {
                Checkpoint oldCheckPoint = checkpoints[checkpoints.length-1];
@@ -528,6 +528,16 @@ contract MiniMeToken is Controlled {
         } else {
             throw;
         }
+    }
+
+
+//////////
+// Testing specific methods
+//////////
+
+    /// @notice This function is overridden by the test Mocks.
+    function getBlockNumber() internal constant returns (uint256) {
+        return block.number;
     }
 
 //////////

--- a/contracts/SNTPlaceHolder.sol
+++ b/contracts/SNTPlaceHolder.sol
@@ -83,7 +83,7 @@ contract SNTPlaceHolder is TokenController, Owned {
     function transferable(address _from) internal returns (bool) {
         // Allow the exchanger to work from the beginning
         if (activationTime == 0) {
-            uint256 f = contribution.finalized();
+            uint256 f = contribution.finalizedTime();
             if (f > 0) {
                 activationTime = f.add(1 weeks);
             } else {

--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -64,7 +64,8 @@ contract StatusContribution is Owned, TokenController {
     uint256 public totalGuaranteedCollected;
     uint256 public totalNormalCollected;
 
-    uint256 public finalized;
+    uint256 public finalizedBlock;
+    uint256 public finalizedTime;
 
     modifier initialized() {
         if (address(SNT) == 0x0 ) throw;
@@ -74,7 +75,7 @@ contract StatusContribution is Owned, TokenController {
     modifier contributionOpen() {
         if ((getBlockNumber() < startBlock) ||
             (getBlockNumber() > endBlock) ||
-            (finalized > 0) ||
+            (finalizedBlock > 0) ||
             (address(SNT) == 0x0 ))
             throw;
         _;
@@ -302,7 +303,7 @@ contract StatusContribution is Owned, TokenController {
     function finalize() public initialized {
         if (getBlockNumber() < startBlock) throw;
         if (msg.sender != owner && getBlockNumber() <= endBlock) throw;
-        if (finalized > 0) throw;
+        if (finalizedBlock > 0) throw;
 
         // Do not allow terminate until all revealed.
         if (!dynamicCeiling.allRevealed()) throw;
@@ -314,7 +315,8 @@ contract StatusContribution is Owned, TokenController {
             if (totalCollected() < lastLimit - 1 ether) throw;
         }
 
-        finalized = now;
+        finalizedBlock = getBlockNumber();
+        finalizedTime = now;
 
         uint256 percentageToSgt;
         if (SGT.totalSupply() >= maxSGTSupply) {

--- a/test/claimExternal.js
+++ b/test/claimExternal.js
@@ -60,7 +60,7 @@ contract("StatusContribution", (accounts) => {
             multisigDevs.address,
             statusContribution.address,
             snt.address);
-        sgtExchanger = await SGTExchanger.new(sgt.address, snt.address);
+        sgtExchanger = await SGTExchanger.new(sgt.address, snt.address, statusContribution.address);
         dynamicCeiling = await DynamicCeiling.new();
 
         await setHiddenPoints(dynamicCeiling, points);

--- a/test/contribution.js
+++ b/test/contribution.js
@@ -1,8 +1,8 @@
 // Simulate a full contribution
 
 const MiniMeTokenFactory = artifacts.require("MiniMeTokenFactory");
-const SGT = artifacts.require("SGT");
-const SNT = artifacts.require("SNT");
+const SGT = artifacts.require("SGTMock");
+const SNT = artifacts.require("SNTMock");
 const MultiSigWallet = artifacts.require("MultiSigWallet");
 const ContributionWallet = artifacts.require("ContributionWallet");
 const StatusContributionMock = artifacts.require("StatusContributionMock");
@@ -62,7 +62,7 @@ contract("StatusContribution", (accounts) => {
             multisigDevs.address,
             statusContribution.address,
             snt.address);
-        sgtExchanger = await SGTExchanger.new(sgt.address, snt.address);
+        sgtExchanger = await SGTExchanger.new(sgt.address, snt.address, statusContribution.address);
         dynamicCeiling = await DynamicCeiling.new();
 
         await setHiddenPoints(dynamicCeiling, points);
@@ -129,6 +129,8 @@ contract("StatusContribution", (accounts) => {
             web3.sha3("pwd0"));
 
         await statusContribution.setMockedBlockNumber(1000000);
+        await sgt.setMockedBlockNumber(1000000);
+        await snt.setMockedBlockNumber(1000000);
 
         lim = 3;
         cur = 0;
@@ -163,6 +165,8 @@ contract("StatusContribution", (accounts) => {
 
     it("Should return the remaining in the last transaction ", async () => {
         await statusContribution.setMockedBlockNumber(1005000);
+        await sgt.setMockedBlockNumber(1005000);
+        await snt.setMockedBlockNumber(1005000);
         const initialBalance = await web3.eth.getBalance(accounts[0]);
         await snt.sendTransaction({value: web3.toWei(5), gas: 300000, gasPrice: "20000000000"});
         const finalBalance = await web3.eth.getBalance(accounts[0]);
@@ -189,6 +193,8 @@ contract("StatusContribution", (accounts) => {
             web3.sha3("pwd1"));
 
         await statusContribution.setMockedBlockNumber(1005000);
+        await sgt.setMockedBlockNumber(1005000);
+        await snt.setMockedBlockNumber(1005000);
 
         const initialBalance = await web3.eth.getBalance(accounts[0]);
         await snt.sendTransaction({value: web3.toWei(10), gas: 300000, gasPrice: "20000000000"});
@@ -217,6 +223,8 @@ contract("StatusContribution", (accounts) => {
             web3.sha3("pwd2"));
 
         await statusContribution.setMockedBlockNumber(1025000);
+        await sgt.setMockedBlockNumber(1025000);
+        await snt.setMockedBlockNumber(1025000);
 
         const initialBalance = await web3.eth.getBalance(accounts[0]);
         await statusContribution.proxyPayment(

--- a/test/helpers/SGTMock.sol
+++ b/test/helpers/SGTMock.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.4.8;
+
+import '../../contracts/SGT.sol';
+
+// @dev AragonTokenSaleMock mocks current block number
+
+contract SGTMock is SGT {
+
+    function SGTMock(address _tokenFactory) SGT(_tokenFactory) {}
+
+    function getBlockNumber() internal constant returns (uint) {
+        return mock_blockNumber;
+    }
+
+    function setMockedBlockNumber(uint _b) public {
+        mock_blockNumber = _b;
+    }
+
+    uint mock_blockNumber = 1;
+}

--- a/test/helpers/SNTMock.sol
+++ b/test/helpers/SNTMock.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.4.8;
+
+import '../../contracts/SNT.sol';
+
+// @dev AragonTokenSaleMock mocks current block number
+
+contract SNTMock is SNT {
+
+    function SNTMock(address _tokenFactory) SNT(_tokenFactory) {}
+
+    function getBlockNumber() internal constant returns (uint) {
+        return mock_blockNumber;
+    }
+
+    function setMockedBlockNumber(uint _b) public {
+        mock_blockNumber = _b;
+    }
+
+    uint mock_blockNumber = 1;
+}


### PR DESCRIPTION
This PR, freezes the distribution used of the SGTExchanger at that specific point.
This has the following implications:
1.- The SGT distribution is fixed at finalize time. Even if it's modified later, it will have no effect in the SGTExchange.  This allow keep adding SGT tokens in the future, but will not receive SNT.
2.- Only SGT addresses with tokens at finalize contribution time will receive SNT. This allow to transfers SGT tokens in the future without compromising this exchange.
