### PR TITLE
Antispam mechanism

### DIFF
--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -39,6 +39,7 @@ contract StatusContribution is Owned, TokenController {
     uint256 constant public failSafe = 300000 ether;
     uint256 constant public exchangeRate = 10000;
     uint256 constant public maxGasPrice = 50000000000;
+    uint256 constant public MaxCallFrequency = 100;
 
     MiniMeToken public SGT;
     MiniMeToken public SNT;
@@ -62,6 +63,8 @@ contract StatusContribution is Owned, TokenController {
     uint256 public totalNormalCollected;
 
     uint256 public finalized;
+
+    mapping (address => uint256) public lastCallBlock;
 
     modifier initialized() {
         if (address(SNT) == 0x0 ) throw;
@@ -201,6 +204,20 @@ contract StatusContribution is Owned, TokenController {
 
     function buyNormal(address _th) internal {
         if (tx.gasprice > maxGasPrice) throw;
+
+        // Antispam mechanism
+        address caller;
+        if (msg.sender == address(SNT)) {
+            caller = _th;
+        } else {
+            caller = msg.sender;
+        }
+
+        // Do not allow make tricki contracts to game the system
+        if (isContract(caller)) throw;
+
+        if (getBlockNumber().sub(lastCallBlock[caller]) < MaxCallFrequency) throw;
+        lastCallBlock[caller] = getBlockNumber();
 
         uint256 toCollect = dynamicCeiling.toCollect(totalNormalCollected);
         if (totalNormalCollected.add(toCollect) > failSafe) throw;
@@ -375,6 +392,18 @@ contract StatusContribution is Owned, TokenController {
 
     function percent(uint256 p) internal returns (uint256) {
         return p.mul(10**16);
+    }
+
+    /// @dev Internal function to determine if an address is a contract
+    /// @param _addr The address being queried
+    /// @return True if `_addr` is a contract
+    function isContract(address _addr) constant internal returns(bool) {
+        uint size;
+        if (_addr == 0) return false;
+        assembly {
+            size := extcodesize(_addr)
+        }
+        return size>0;
     }
 
 


### PR DESCRIPTION
This mechanism prevents a user spam the network with many transactions.

The can always send it from many accounts, but they risk to spend much more Ether that what they want.