### PR TITLE
Testing for the web3 error outside the try catch statement

### DIFF
--- a/test/contribution.js
+++ b/test/contribution.js
@@ -99,11 +99,9 @@ contract("StatusContribution", (accounts) => {
     });
 
     it("Checks that no body can buy before the sale starts", async () => {
-        try {
+        await assertFail(async () => {
             await snt.send(web3.toWei(1));
-        } catch (error) {
-            assertFail(error);
-        }
+        });
     });
 
     it("Add 2 guaranteed addresses ", async () => {
@@ -243,11 +241,9 @@ contract("StatusContribution", (accounts) => {
     });
 
     it("Should not allow transfers in contribution period", async () => {
-        try {
+        await assertFail(async () => {
             await snt.transfer(accounts[4], web3.toWei(1000));
-        } catch (error) {
-            assertFail(error);
-        }
+        });
     });
 
     it("Guaranteed address should still be able to buy", async () => {
@@ -300,11 +296,9 @@ contract("StatusContribution", (accounts) => {
     });
 
     it("Should not allow transfers in the 1 week period", async () => {
-        try {
+        await assertFail(async () => {
             await snt.transfer(accounts[4], web3.toWei(1000));
-        } catch (error) {
-            assertFail(error);
-        }
+        });
     });
 
     it("Should allow transfers after 1 week period", async () => {
@@ -322,15 +316,13 @@ contract("StatusContribution", (accounts) => {
         const t = Math.floor(new Date().getTime() / 1000) + (86400 * 7) + 1000;
         await devTokensHolder.setMockedTime(t);
 
-        try {
+        await assertFail(async () => {
             await multisigDevs.submitTransaction(
                 devTokensHolder.address,
                 0,
                 devTokensHolder.contract.collectTokens.getData(),
                 {from: accounts[3]});
-        } catch (error) {
-            assertFail(error);
-        }
+        });
     });
 
     it("Devs Should be able to extract 1/2 after a year", async () => {

--- a/test/helpers/assertFail.js
+++ b/test/helpers/assertFail.js
@@ -1,4 +1,9 @@
-module.exports = (error) => {
-    if (error.message.search("invalid opcode")) return;
-    assert.ok(false, "Transaction should fail");
+module.exports = async (callback) => {
+    let web3_error_thrown = false;
+    try {
+        await callback();
+    } catch (error) {
+        if (error.message.search("invalid opcode")) web3_error_thrown = true;
+    }
+    assert.ok(web3_error_thrown, "Transaction should fail");
 };


### PR DESCRIPTION
The `assertFail` was only being called in the `catch` block, therefore, the tests would always pass, either the contract throws an exception and the test catches it and checks the message, or the contract doesn't throw an exception and the test doesn't execute the catch.

This small change will evaluate the exception **after** the `try catch` is performed thus ensuring that the test is actually checking the desired outcome.

## However

This change did surface an issue on test `test/contribution.js:315` `Devs should not allow transfers before 6 months`.

This should be addressed.