### PR TITLE
contracts: StatusContribution: Guarantee SGT holders

### DIFF
--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -229,10 +229,10 @@ contract StatusContribution is Owned, TokenController {
 
     function buyGuaranteed(address _th) internal {
         uint256 toFund;
-        uint256 cap = guaranteedBuyersLimit[_th];
+        uint256 toCollect = guaranteedBuyersLimit[_th];
 
-        if (guaranteedBuyersBought[_th].add(msg.value) > cap) {
-            toFund = cap.sub(guaranteedBuyersBought[_th]);
+        if (guaranteedBuyersBought[_th].add(msg.value) > toCollect) {
+            toFund = toCollect.sub(guaranteedBuyersBought[_th]);
         } else {
             toFund = msg.value;
         }

--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -40,7 +40,6 @@ contract StatusContribution is Owned, TokenController {
     uint256 constant public failSafe = 300000 ether;
     uint256 constant public exchangeRate = 10000;
     uint256 constant public maxGasPrice = 50000000000;
-    uint256 constant public limitSGT = 30 ether;
 
     MiniMeToken public SGT;
     MiniMeToken public SNT;
@@ -59,7 +58,6 @@ contract StatusContribution is Owned, TokenController {
 
     mapping (address => uint256) public guaranteedBuyersLimit;
     mapping (address => uint256) public guaranteedBuyersBought;
-    mapping (address => uint256) public sgtCollected;
 
     uint256 public totalGuaranteedCollected;
     uint256 public totalNormalCollected;
@@ -214,15 +212,6 @@ contract StatusContribution is Owned, TokenController {
             toFund = msg.value;
         } else {
             toFund = toCollect;
-        }
-
-        uint256 currentIndex = dynamicCeiling.currentIndex();
-        if (currentIndex == 0) {
-            require(SGT.balanceOf(_th) > 0);
-            if (sgtCollected[_th].add(toFund) > limitSGT) {
-                toFund = limitSGT.sub(sgtCollected[_th]);
-            }
-            sgtCollected[_th] = sgtCollected[_th].add(toFund);
         }
 
         totalNormalCollected = totalNormalCollected.add(toFund);

--- a/test/contribution.js
+++ b/test/contribution.js
@@ -47,8 +47,7 @@ contract("StatusContribution", (accounts) => {
         multisigDevs = await MultiSigWallet.new([accounts[3]], 1);
         miniMeFactory = await MiniMeTokenFactory.new();
         sgt = await SGT.new(miniMeFactory.address);
-        await sgt.generateTokens(accounts[4], 2500);
-        await sgt.generateTokens(accounts[0], 2500);
+        await sgt.generateTokens(accounts[9], 2500);
 
         snt = await SNT.new(miniMeFactory.address);
         statusContribution = await StatusContributionMock.new();
@@ -272,7 +271,7 @@ contract("StatusContribution", (accounts) => {
         assert.isBelow(web3.fromWei(totalSupply).toNumber() - (180000 / 0.46), 0.01);
 
         const balanceSGT = await snt.balanceOf(sgtExchanger.address);
-        assert.equal(balanceSGT.toNumber(), totalSupply.mul(0.05).toNumber());
+        assert.equal(balanceSGT.toNumber(), totalSupply.mul(0.025).toNumber());
 
         const balanceDevs = await snt.balanceOf(devTokensHolder.address);
         assert.equal(balanceDevs.toNumber(), totalSupply.mul(0.20).toNumber());
@@ -293,9 +292,9 @@ contract("StatusContribution", (accounts) => {
     });
 
     it("Should be able to exchange sgt by snt", async () => {
-        await sgtExchanger.collect({from: accounts[4]});
+        await sgtExchanger.collect({from: accounts[9]});
 
-        const balance = await snt.balanceOf(accounts[4]);
+        const balance = await snt.balanceOf(accounts[9]);
         const totalSupply = await snt.totalSupply();
 
         assert.equal(totalSupply.mul(0.025).toNumber(), balance.toNumber());


### PR DESCRIPTION
Make every SGT holder a guaranteed address at first contribution, when the limit has been reached everything functions as normal.

Better solution than #84.

Fixes #81.