### PR TITLE
Moving failsafe check to doBuy so that it covers both normal and guar…

### DIFF
--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -205,7 +205,6 @@ contract StatusContribution is Owned, TokenController {
         require(tx.gasprice <= maxGasPrice);
 
         uint256 toCollect = dynamicCeiling.toCollect(totalNormalCollected);
-        assert(totalNormalCollected.add(toCollect) <= failSafe);
 
         uint256 toFund;
         if (msg.value <= toCollect) {
@@ -236,6 +235,10 @@ contract StatusContribution is Owned, TokenController {
 
     function doBuy(address _th, uint256 _toFund, bool _guaranteed) internal {
         require(msg.value >= _toFund);  // Not needed, but double check.
+
+        uint256 totalCollected = totalNormalCollected.add(totalGuaranteedCollected);
+        uint256 toCollect = dynamicCeiling.toCollect(totalCollected);
+        assert(totalCollected.add(toCollect) <= failSafe);
 
         if (_toFund > 0) {
             uint256 tokensGenerated = _toFund.mul(exchangeRate);


### PR DESCRIPTION
…anteed transactions.

This pulls request concerns this [issue](https://github.com/status-im/status-network-token/issues/86). It makes sure that the contract can never get funded for more than `failsafe`. 

As I mentioned in the issue, this is unlikely to be a real problem since the guaranteed buyers will most likely be contributing during the first ceiling anyways. But this avoids a situation where "normal" (as in non-guaranteed) contributors fund all of the ceilings, and then the guaranteed buyers come in and broadcast their transaction and get their guaranteed funding. In the end, this could mean that the contract is funded for more than `failsafe`, e.g., final ceiling is 250,000 ETH, guaranteed buyers get 100,000 ETH for a total funding of 350,000 ETH.

With this PR, both a normal and guaranteed transaction would fail if it means going over the `failsafe`. 