### PR TITLE
Sgt Controller should not be SGT exchange.

### DIFF
--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -140,7 +140,6 @@ contract StatusContribution is Owned, TokenController {
         destTokensSecondarySale = _destTokensSecondarySale;
 
         require(_sgt != 0x0);
-        require(MiniMeToken(_sgt).controller() == _destTokensSgt);
         SGT = MiniMeToken(_sgt);
 
         require(_destTokensSgt != 0x0);

--- a/test/claimExternal.js
+++ b/test/claimExternal.js
@@ -70,7 +70,6 @@ contract("StatusContribution", (accounts) => {
             sgtExchanger.address);
 
         await snt.changeController(statusContribution.address);
-        await sgt.changeController(sgtExchanger.address);
 
         await statusContribution.initialize(
             snt.address,

--- a/test/contribution.js
+++ b/test/contribution.js
@@ -72,7 +72,6 @@ contract("StatusContribution", (accounts) => {
             sgtExchanger.address);
 
         await snt.changeController(statusContribution.address);
-        await sgt.changeController(sgtExchanger.address);
 
         await statusContribution.initialize(
             snt.address,
@@ -95,7 +94,6 @@ contract("StatusContribution", (accounts) => {
 
     it("Check initial parameters", async () => {
         assert.equal(await snt.controller(), statusContribution.address);
-        assert.equal(await sgt.controller(), sgtExchanger.address);
     });
 
     it("Checks that no body can buy before the sale starts", async () => {

--- a/test/dynamicCeiling.js
+++ b/test/dynamicCeiling.js
@@ -193,7 +193,7 @@ contract("DynamicCeiling", (accounts) => {
                 web3.sha3("pwd0"),
                 web3.sha3("pwd1"),
                 web3.sha3("pwd2"),
-            ],
+            ]
         );
 
         assert.equal(await dynamicCeiling.currentIndex(), 0);


### PR DESCRIPTION
Since SGTexchange does not burn SGT tokens in exchange of SNT anymore. It is not necessary that SGTExchange be the controller of SGT token contract.  
This way, status team can still keep distributing sgt.
In the init function of StatusDistrivution contract this check was done, and now it's not needed any more, and even more it's absolutely necessary to remove this check if we cont to keep the controller  for SGT the Status team.
If this PR is not accepted, Status teem will not be able to keep giving SGT tokens after the contribution period.