### PR TITLE
Change in the order of execution of the formula

### DIFF
--- a/contracts/DevTokensHolder.sol
+++ b/contracts/DevTokensHolder.sol
@@ -71,7 +71,7 @@ contract DevTokensHolder is Owned {
 
         require(finalizedTime > 0 && getTime() > finalizedTime.add(months(6)));
 
-        uint256 canExtract = total.mul(getTime().sub(finalizedTime).div(months(24)));
+        uint256 canExtract = total.mul(getTime().sub(finalizedTime)).div(months(24));
 
         canExtract = canExtract.sub(collectedTokens);
 

--- a/test/contribution.js
+++ b/test/contribution.js
@@ -337,7 +337,7 @@ contract("StatusContribution", (accounts) => {
         const t = (await statusContribution.finalizedTime()).toNumber() + (86400 * 360);
         await devTokensHolder.setMockedTime(t);
 
-        const tokenHolderBalance = await snt.balanceOf(devTokensHolder.address);
+        const totalSupply = await snt.totalSupply();
 
         await multisigDevs.submitTransaction(
             devTokensHolder.address,
@@ -347,7 +347,7 @@ contract("StatusContribution", (accounts) => {
 
         const balance = await snt.balanceOf(multisigDevs.address);
 
-        const calcTokens = web3.fromWei(tokenHolderBalance.mul(0.5)).toNumber();
+        const calcTokens = web3.fromWei(totalSupply.mul(0.20).mul(0.5)).toNumber();
         const realTokens = web3.fromWei(balance).toNumber();
 
         assert.equal(realTokens, calcTokens);

--- a/test/contribution.js
+++ b/test/contribution.js
@@ -334,10 +334,10 @@ contract("StatusContribution", (accounts) => {
     });
 
     it("Devs Should be able to extract 1/2 after a year", async () => {
-        const t = Math.floor(new Date().getTime() / 1000) + (86400 * 360);
+        const t = (await statusContribution.finalizedTime()).toNumber() + (86400 * 360);
         await devTokensHolder.setMockedTime(t);
 
-        const totalSupply = await snt.totalSupply();
+        const tokenHolderBalance = await snt.balanceOf(devTokensHolder.address);
 
         await multisigDevs.submitTransaction(
             devTokensHolder.address,
@@ -347,10 +347,10 @@ contract("StatusContribution", (accounts) => {
 
         const balance = await snt.balanceOf(multisigDevs.address);
 
-        const calcTokens = web3.fromWei(totalSupply.mul(0.20).mul(0.5)).toNumber();
+        const calcTokens = web3.fromWei(tokenHolderBalance.mul(0.5)).toNumber();
         const realTokens = web3.fromWei(balance).toNumber();
 
-        assert.isBelow(realTokens - calcTokens, 0.1);
+        assert.equal(realTokens, calcTokens);
     });
 
     it("Devs Should be able to extract every thing after 2 year", async () => {


### PR DESCRIPTION
The current implementation of the linear formula will allow 0 tokens to be extracted until 2 years have passed because `div()` returns a `uint` so any value below 1 will be floored to 0.

The quick change would be to change the order of execution.

```
\\ the division is executed last.
uint256 canExtract = total.mul(getTime().sub(finalizedTime)).div(months(24));
```

However, depending on the number of tokens held by the contract, the multiplication could overflow but that is very unlikely.

If the Status team thinks that the multiplication could overflow, a possible solution could be to count time in days instead of seconds.

```
uint256 canExtract = total.mul(getTime().sub(finalizedTime).div(86400)).div(720);
```

Also, I changed the test so it checks for the exact amount that can be collected.