### PR TITLE
Throw when no operation is done by the user

### DIFF
--- a/contracts/SGTExchanger.sol
+++ b/contracts/SGTExchanger.sol
@@ -64,6 +64,8 @@ contract SGTExchanger is TokenController, Owned {
         // And then subtract the amount already collected
         amount = amount.sub(collected[msg.sender]);
 
+        require(amount>0); // Notify the user that there is no tokens to exchange
+
         totalCollected = totalCollected.add(amount);
         collected[msg.sender] = collected[msg.sender].add(amount);
 

--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -236,7 +236,6 @@ contract StatusContribution is Owned, TokenController {
     function doBuy(address _th, uint256 _toFund, bool _guaranteed) internal {
         assert(msg.value >= _toFund);  // Not needed, but double check.
         assert(totalCollected() <= failSafeLimit);
-        require(_toFund > 0);  // Throw to notify the user.
 
         if (_toFund > 0) {
             uint256 tokensGenerated = _toFund.mul(exchangeRate);

--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -236,6 +236,7 @@ contract StatusContribution is Owned, TokenController {
     function doBuy(address _th, uint256 _toFund, bool _guaranteed) internal {
         assert(msg.value >= _toFund);  // Not needed, but double check.
         assert(totalCollected() <= failSafeLimit);
+        require(_toFund > 0);  // Throw to notify the user.
 
         if (_toFund > 0) {
             uint256 tokensGenerated = _toFund.mul(exchangeRate);


### PR DESCRIPTION
In the case of an OP after the ceiling is reached, 0 tokens will be bought. It's good idea to throw in this cirmustance so it's more easy to monitor.