### PR TITLE
Emergency pause the contribution

### DIFF
--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -465,7 +465,7 @@ contract StatusContribution is Owned, TokenController {
     }
 
 
-    /// @notice Emergency method the pause the contribution if there is any issue
+    /// @notice Pauses the contribution if there is any issue
     function pauseContribution() onlyOwner {
         paused = true;
     }

--- a/contracts/StatusContribution.sol
+++ b/contracts/StatusContribution.sol
@@ -89,7 +89,9 @@ contract StatusContribution is Owned, TokenController {
         _;
     }
 
-    function StatusContribution() {}
+    function StatusContribution() {
+        paused = false;
+    }
 
 
     /// @notice This method should be called by the owner before the contribution

--- a/test/contribution.js
+++ b/test/contribution.js
@@ -149,10 +149,17 @@ contract("StatusContribution", function(accounts) {
 
         assert.equal(web3.fromWei(balance).toNumber(), b * 10000);
     });
-    it("Returns the remaining of the last transaction ", async function() {
+    it("Pauses and resumes the contribution ", async function() {
         await statusContribution.setMockedBlockNumber(1005000);
         await sgt.setMockedBlockNumber(1005000);
         await snt.setMockedBlockNumber(1005000);
+        await statusContribution.pauseContribution();
+        await assertFail(async function() {
+            await snt.sendTransaction({value: web3.toWei(5), gas: 300000, gasPrice: "20000000000"});
+        });
+        await statusContribution.resumeContribution();
+    });
+    it("Returns the remaining of the last transaction ", async function() {
         const initialBalance = await web3.eth.getBalance(addressStatus);
         await snt.sendTransaction({value: web3.toWei(5), gas: 300000, gasPrice: "20000000000"});
         const finalBalance = await web3.eth.getBalance(addressStatus);


### PR DESCRIPTION
If for any circumstances there is any security issue during the contribution, this methods allows to pause and resume the contribution.
This method is also very important if we have to redeploy the smart contracts. In that circumstance, this method allows to stop the old contract avoiding to collect any Ether sent to the old contract erroneously or because didn't realize of the change.